### PR TITLE
Add requirement that references to "the team" be avoided.

### DIFF
--- a/src/jobs/project_rollup.ts
+++ b/src/jobs/project_rollup.ts
@@ -159,7 +159,9 @@ New messages (chronological):\n${body}
 Requirements:
 - 1-3 sentences, crisp and specific about what progressed, decisions, blockers, and next steps.
 - Include names of key contributors if clear.
-- Avoid pleasantries and meta-chatter.`;
+- Avoid pleasantries and meta-chatter.
+- Assume that there's only a single contributor to the project. Unless clearly stated that a team
+  is involved, avoid references to "the team" in the summary.`;
 }
 
 async function summarizeWithOpenAI(prompt: string): Promise<string | null> {


### PR DESCRIPTION
Added another requirement to the LLM instructions, with the intent that references to "the team" be avoided in favor of the assumption that each project only has a single contributor.